### PR TITLE
setup.pyのバージョン更新

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -389,8 +389,8 @@ install.sub_commands = [c for c in install.sub_commands
 install.sub_commands.insert(2, ('install_scripts', None))
 
 
-setuptools.setup(name='rtshell',
-                 version='4.2.2',
+setuptools.setup(name='rtshell-aist',
+                 version='4.2.3',
                  description='Shell commands for managing RT Components and RT Systems.',
                  author='Geoffrey Biggs and contributors',
                  author_email='geoffrey.biggs@aist.go.jp',
@@ -405,6 +405,11 @@ setuptools.setup(name='rtshell',
                      'Natural Language :: English',
                      'Operating System :: OS Independent',
                      'Programming Language :: Python :: 2.7',
+                     'Programming Language :: Python :: 3.5',
+                     'Programming Language :: Python :: 3.6',
+                     'Programming Language :: Python :: 3.7',
+                     'Programming Language :: Python :: 3.8',
+                     'Programming Language :: Python :: 3.9',
                      'Topic :: Software Development',
                      'Topic :: Utilities'
                      ],


### PR DESCRIPTION
rtshellのバージョンを4.1.3に更新した。
rtshellは以下のプロジェクトにアップロードするため、名前を`rtshell`から`rtshell-aist`に変更した。

- https://pypi.org/manage/project/rtshell-aist/releases/

対応するPythonのバージョンに3.5、3.6、3.7、3.8、3.9を追加した。