### PR TITLE
bash_completionの改行コード自動変換を無効にする

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -291,10 +291,10 @@ class BuildShellSupport(Command):
         COMPOPT_FILENAME = 'compopt -o filenames'
         COMPLETE_NOSPACE = '-o nospace'
         if sys.version_info[0] == 2:
-            with open(os.path.join('data', 'bash_completion.in'), 'rt') as f:
+            with open(os.path.join('data', 'bash_completion.in'), 'rt', newline='') as f:
                 bash_comp = f.read()
         else:
-            with open(os.path.join('data', 'bash_completion.in'), 'rt', encoding='utf-8') as f:
+            with open(os.path.join('data', 'bash_completion.in'), 'rt', encoding='utf-8', newline='') as f:
                 bash_comp = f.read()
         if sys.platform == 'darwin':
             bash_comp = bash_comp.replace('@COMPOPT_NOSPACE@', ':')
@@ -308,7 +308,7 @@ class BuildShellSupport(Command):
         bash_completion_path = os.path.join(bash_completion_dir, 'bash_completion')
         if not os.path.isdir(bash_completion_dir):
             self.mkpath(bash_completion_dir)
-        with open(bash_completion_path, 'w') as f:
+        with open(bash_completion_path, 'w', newline='') as f:
             f.write(bash_comp)
 
     def copy_shell_support(self):

--- a/setup.py
+++ b/setup.py
@@ -390,7 +390,7 @@ install.sub_commands.insert(2, ('install_scripts', None))
 
 
 setuptools.setup(name='rtshell-aist',
-                 version='4.2.4',
+                 version='4.2.7',
                  description='Shell commands for managing RT Components and RT Systems.',
                  author='Geoffrey Biggs and contributors',
                  author_email='geoffrey.biggs@aist.go.jp',

--- a/setup.py
+++ b/setup.py
@@ -308,7 +308,7 @@ class BuildShellSupport(Command):
         bash_completion_path = os.path.join(bash_completion_dir, 'bash_completion')
         if not os.path.isdir(bash_completion_dir):
             self.mkpath(bash_completion_dir)
-        with open(bash_completion_path, 'w', newline='') as f:
+        with open(bash_completion_path, 'w', encoding='utf-8', newline='') as f:
             f.write(bash_comp)
 
     def copy_shell_support(self):


### PR DESCRIPTION
setup.pyをWindowsで実行した場合、setup.pyで生成したbash_completionの改行コードがLFからCRLFに変換されるため、変換されないようにした。
またbash_completionの文字コードがBOM無しUTF-8からSHIFT-JISに変わる問題も修正した。