### PR TITLE
COPYRIGHTファイル新設と連絡先情報の更新

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,10 @@
+
+Copyright (C) 2009-2021
+    Geoffrey Biggs
+    RT-Synthesis Research Group
+    Intelligent Systems Research Institute,
+    National Institute of Advanced Industrial Science and Technology (AIST),
+    Japan
+    All rights reserved.
+Licensed under the GNU Lesser General Public License version 3.
+http://www.gnu.org/licenses/lgpl-3.0.en.html

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,8 +1,6 @@
 
 Copyright (C) 2009-2021
-    Geoffrey Biggs
-    RT-Synthesis Research Group
-    Intelligent Systems Research Institute,
+    Geoffrey Biggs, Noriaki Ando
     National Institute of Advanced Industrial Science and Technology (AIST),
     Japan
     All rights reserved.

--- a/setup.py
+++ b/setup.py
@@ -392,7 +392,7 @@ install.sub_commands.insert(2, ('install_scripts', None))
 setuptools.setup(name='rtshell-aist',
                  version='4.2.4',
                  description='Shell commands for managing RT Components and RT Systems.',
-                 author='Noriaki Ando and contributors',
+                 author='Geoffrey Biggs, Noriaki Ando and contributors',
                  author_email='n-ando@aist.go.jp',
                  url='https://github.com/OpenRTM/rtshell',
                  license='LGPL3',

--- a/setup.py
+++ b/setup.py
@@ -392,9 +392,9 @@ install.sub_commands.insert(2, ('install_scripts', None))
 setuptools.setup(name='rtshell-aist',
                  version='4.2.4',
                  description='Shell commands for managing RT Components and RT Systems.',
-                 author='Geoffrey Biggs and contributors',
-                 author_email='geoffrey.biggs@aist.go.jp',
-                 url='http://github.com/gbiggs/rtshell',
+                 author='Noriaki Ando and contributors',
+                 author_email='n-ando@aist.go.jp',
+                 url='https://github.com/OpenRTM/rtshell',
                  license='LGPL3',
                  long_description='Shell commands for managing RT-Middleware.',
                  classifiers=[


### PR DESCRIPTION
Link to #19 

- 各Pythonファイルに書かれている Copyright を新設した rtshell/COPYRIGHT に記載
- 今後更新年をアップデートする際は、このCOPYRIGHTファイルのみ更新する
- setup.py に記載している連絡先情報を更新した