### PR TITLE
rtshell_post_install実行時に更新する.bashrcのパス変更

### DIFF
--- a/rtshell/post_install.py
+++ b/rtshell/post_install.py
@@ -151,10 +151,10 @@ def add_shell_support(prefix, bashrc_path=None):
     script_path = pkg_resources.resource_filename('rtshell.data',
             'shell_support')
     source_line = 'source {}'.format(os.path.abspath(script_path))
-    if not bashrc_path:
-        bashrc_path = os.path.expanduser('~/.bashrc')
-    else:
-        bashrc_path = os.path.expanduser(bashrc_path)
+    username = os.getenv('SUDO_USER')
+    if not username:
+        username = os.getenv('USER')
+    bashrc_path = os.path.expanduser('~' + username + '/.bashrc')
     if os.path.exists(bashrc_path) and os.path.isfile(bashrc_path):
         # Check if the source line already exists
         with open(bashrc_path, 'r') as f:


### PR DESCRIPTION
Link to #9 

- sudo rtshell_post_install を実行した時、Ubuntu18.04は $HOME/.bashrc を更新するが、Raspbian buster と Ubuntu20.04 は /root/.bashrc を更新していた
- これを、sudo で実行しても $HOME/.bashrc を更新するように修正した
- 動作確認は、ローカルでビルドしたwhlファイルをインストールして行った
```
$ python3 setup.py bdist_wheel
$ sudo pip3 install ./dist/rtshell_aist-4.2.7-py3-none-any.whl --no-index
$ sudo rtshell_post_install
```
- rtshell_post_installスクリプトはsudoなしで以下のように実行した場合でも問題なく$HOME/.bashrc が更新されることを確認した
```
$ rtshell_post_install
Link man pages? n
Link documentation? n
Add shell support to .bashrc? y
```