### PR TITLE
Linux+Python3環境のための修正

### DIFF
--- a/data/shell_support
+++ b/data/shell_support
@@ -9,9 +9,9 @@
 # http://www.gnu.org/licenses/lgpl-3.0.en.html
 
 if [ `uname` = "Darwin" ]; then
-   PYTHON_COMMAND=python
+   PYTHON_COMMAND=python3
 elif [ `uname` = "Linux" ]; then
-   PYTHON_COMMAND=python
+   PYTHON_COMMAND=python3
 fi
 
 rtcwd()

--- a/rtshell/comp_mgmt.py
+++ b/rtshell/comp_mgmt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/fmt.py
+++ b/rtshell/fmt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/gen_comp.py
+++ b/rtshell/gen_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/ilog.py
+++ b/rtshell/ilog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/modmgr.py
+++ b/rtshell/modmgr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/path.py
+++ b/rtshell/path.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/port_types.py
+++ b/rtshell/port_types.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtact.py
+++ b/rtshell/rtact.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtcat.py
+++ b/rtshell/rtcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtcheck.py
+++ b/rtshell/rtcheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtcomp.py
+++ b/rtshell/rtcomp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtcon.py
+++ b/rtshell/rtcon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtconf.py
+++ b/rtshell/rtconf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtcryo.py
+++ b/rtshell/rtcryo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtcwd.py
+++ b/rtshell/rtcwd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtdeact.py
+++ b/rtshell/rtdeact.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtdel.py
+++ b/rtshell/rtdel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtdis.py
+++ b/rtshell/rtdis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtdoc.py
+++ b/rtshell/rtdoc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtexit.py
+++ b/rtshell/rtexit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtfind.py
+++ b/rtshell/rtfind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtfsm.py
+++ b/rtshell/rtfsm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtinject.py
+++ b/rtshell/rtinject.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtinject_comp.py
+++ b/rtshell/rtinject_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtlog.py
+++ b/rtshell/rtlog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtlog_comps.py
+++ b/rtshell/rtlog_comps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtls.py
+++ b/rtshell/rtls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtmgr.py
+++ b/rtshell/rtmgr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtprint.py
+++ b/rtshell/rtprint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtprint_comp.py
+++ b/rtshell/rtprint_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtreset.py
+++ b/rtshell/rtreset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtresurrect.py
+++ b/rtshell/rtresurrect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtstart.py
+++ b/rtshell/rtstart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtstodot.py
+++ b/rtshell/rtstodot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtstop.py
+++ b/rtshell/rtstop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtteardown.py
+++ b/rtshell/rtteardown.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtvlog.py
+++ b/rtshell/rtvlog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/rtwatch.py
+++ b/rtshell/rtwatch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/simpkl_log.py
+++ b/rtshell/simpkl_log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/state_control_base.py
+++ b/rtshell/state_control_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/rtshell/text_log.py
+++ b/rtshell/text_log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/test/c1_comp.py
+++ b/test/c1_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 

--- a/test/c2_comp.py
+++ b/test/c2_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import imp

--- a/test/doc2_comp.py
+++ b/test/doc2_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 

--- a/test/doc_comp.py
+++ b/test/doc_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 

--- a/test/err_comp.py
+++ b/test/err_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 

--- a/test/logfile_unittests.py
+++ b/test/logfile_unittests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/test/mp1_comp.py
+++ b/test/mp1_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 

--- a/test/output_comp.py
+++ b/test/output_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 

--- a/test/output_noport_comp.py
+++ b/test/output_noport_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 

--- a/test/std_comp.py
+++ b/test/std_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 

--- a/test/test_cmds.py
+++ b/test/test_cmds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/test/unittests.py
+++ b/test/unittests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- Python -*-
 # -*- coding: utf-8 -*-
 

--- a/test/zombie_comp.py
+++ b/test/zombie_comp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -*- Python -*-
 


### PR DESCRIPTION
Close #7 
Link to #7 

## Description of the Change

- shell_support内のPythonコマンド指定を、python3 に変更
- `#!/usr/bin/env python2` を `#!/usr/bin/env python3` に変更


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 修正ソースからローカルへインストールした環境で、rtcwd コマンドが動作することを確認した
```
$ rtcwd /localhost
$ rtpwd
/localhost
```
- [x] Did you succeed the build?
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  