### PR TITLE
rtshell_post_installの2回目以降実行時のFileExistsError不具合修正

### DIFF
--- a/rtshell/__init__.py
+++ b/rtshell/__init__.py
@@ -3,7 +3,7 @@
 
 '''rtshell
 
-Copyright (C) 2009-2015
+Copyright (C) 2009-2022
     Geoffrey Biggs
     RT-Synthesis Research Group
     Intelligent Systems Research Institute,
@@ -18,7 +18,7 @@ Commands for managing RT Components and RTM-based systems from a shell.
 '''
 
 
-RTSH_VERSION = '4.2.8'
+RTSH_VERSION = '4.2.9'
 
 
 # vim: tw=79

--- a/rtshell/post_install.py
+++ b/rtshell/post_install.py
@@ -76,7 +76,8 @@ def create_and_link_dir_content(source, dest, dir_type='', remove=False):
         else:
             logging.info('Destination {} directory already exists; skipping: '
                 '{}'.format(dir_type, dest))
-    os.makedirs(dest)
+    else:
+        os.makedirs(dest)
     # Link all files in source
     for f in [f for f in os.listdir(source) if
             os.path.isfile(os.path.join(source, f))]:

--- a/setup.py
+++ b/setup.py
@@ -390,7 +390,7 @@ install.sub_commands.insert(2, ('install_scripts', None))
 
 
 setuptools.setup(name='rtshell-aist',
-                 version='4.2.8',
+                 version='4.2.9',
                  description='Shell commands for managing RT Components and RT Systems.',
                  author='Geoffrey Biggs, Noriaki Ando and contributors',
                  author_email='n-ando@aist.go.jp',


### PR DESCRIPTION
close #26 

## Description of the Change
Link to #26  

- 既にディレクトリが存在していると判断した時、 os.makedirs を実行しないようにelse文を追加した
- バージョンを4.2.9へ、Copyrightを2022へ更新した