### PR TITLE
rtlogで起動したRTCがエラー状態になる問題の修正

### DIFF
--- a/rtshell/simpkl_log.py
+++ b/rtshell/simpkl_log.py
@@ -197,7 +197,7 @@ class SimplePickleLog(ilog.Log):
                 self._file.tell()))
             self._buf_start = self._file.tell()
             # Put some blank space to write the end marker
-            self._file.write(''.ljust(self.BUFFER_SIZE))
+            self._file.write(''.ljust(self.BUFFER_SIZE).encode('utf-8'))
             self._vb_print('Wrote buffer of length {0} at position {1}'.format(
                 self.BUFFER_SIZE, self._buf_start))
             self._write_ind = 0


### PR DESCRIPTION
rtlogコマンドで対象のポートのデータを記録する場合に、新たにRTCを起動して対象のポートと接続してデータを受信するが、onActivated関数内で保存するバイナリファイルに文字列を書き込もうとしてエラーになる箇所があるため修正した。